### PR TITLE
Update doxygen.yml

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Setup
         run: |
           sudo apt install doxygen
+          mkdir build
       - name: Doxygen docs
         run: doxygen Doxyfile
       - name: Upload artifact


### PR DESCRIPTION
We removed `.gitkeep` from `build`, now we have to create the folder before using Doxygen.